### PR TITLE
Expose Clear function on EntityTable

### DIFF
--- a/Chickensoft.Collections.Tests/src/EntityTableTest.cs
+++ b/Chickensoft.Collections.Tests/src/EntityTableTest.cs
@@ -26,4 +26,20 @@ public class EntityTableTest {
     table.Get<string>("a").ShouldBeNull();
     table.Get<object>("b").ShouldNotBeNull();
   }
+
+  [Fact]
+  public void Clears() {
+    var table = new EntityTable();
+
+    table.Set("a", "one");
+    table.Set("b", new object());
+
+    table.Get<string>("a").ShouldBe("one");
+    table.Get<object>("b").ShouldNotBeNull();
+
+    table.Clear();
+
+    table.Get<string>("a").ShouldBeNull();
+    table.Get<object>("b").ShouldBeNull();
+  }
 }

--- a/Chickensoft.Collections/src/collections/entity_table/EntityTableOfTId.cs
+++ b/Chickensoft.Collections/src/collections/entity_table/EntityTableOfTId.cs
@@ -29,6 +29,11 @@ public class EntityTable<TId> where TId : notnull {
   }
 
   /// <summary>
+  /// Clears (but does not dispose) all entities from the table.
+  /// </summary>
+  public void Clear() => _entities.Clear();
+
+  /// <summary>
   /// Retrieve an entity from the table.
   /// </summary>
   /// <typeparam name="TUsage">Type to use the entity as — entity must be


### PR DESCRIPTION
This PR exposes the Clear() function from the underlying `ConcurrentDictionary` in entity table, allowing users to wipe it vs replacing it with a new() (useful when the table is readonly).