### PR TITLE
entity-table: Set now overwrites, TryAdd added for migration path

### DIFF
--- a/Chickensoft.Collections.Tests/src/EntityTableTest.cs
+++ b/Chickensoft.Collections.Tests/src/EntityTableTest.cs
@@ -11,7 +11,7 @@ public class EntityTableTest {
   }
 
   [Fact]
-  public void StoresValues() {
+  public void SetStoresValuesAndOverwritesExistingValues() {
     var table = new EntityTable();
 
     table.Set("a", "one");
@@ -20,11 +20,23 @@ public class EntityTableTest {
     table.Get<string>("a").ShouldBe("one");
     table.Get<object>("b").ShouldNotBeNull();
 
+    table.Set("a", "two");
+    table.Get<string>("a").ShouldBe("two");
+
     table.Remove("a");
     table.Remove(null);
 
     table.Get<string>("a").ShouldBeNull();
     table.Get<object>("b").ShouldNotBeNull();
+  }
+
+  [Fact]
+  public void TryAddOnlyStoresValuesForNewKeys() {
+    var table = new EntityTable();
+
+    table.TryAdd("a", "one").ShouldBeTrue();
+    table.TryAdd("a", "two").ShouldBeFalse();
+    table.Get<string>("a").ShouldBe("one");
   }
 
   [Fact]

--- a/Chickensoft.Collections/src/collections/entity_table/EntityTableOfTId.cs
+++ b/Chickensoft.Collections/src/collections/entity_table/EntityTableOfTId.cs
@@ -16,7 +16,15 @@ public class EntityTable<TId> where TId : notnull {
   /// </summary>
   /// <param name="id">Entity id.</param>
   /// <param name="entity">Entity object.</param>
-  public void Set(TId id, object entity) => _entities.TryAdd(id, entity);
+  public void Set(TId id, object entity) => _entities[id] = entity;
+
+  /// <summary>
+  /// Attempts to add an entity to the table returning true if successful.
+  /// </summary>
+  /// <param name="id">Entity id.</param>
+  /// <param name="entity">Entity object.</param>
+  /// <returns>`true` if the entity was added, `false` otherwise.</returns>
+  public bool TryAdd(TId id, object entity) => _entities.TryAdd(id, entity);
 
   /// <summary>
   /// Remove an entity from the table.


### PR DESCRIPTION
`EntityTable.Set` will now overwrite values if the key already exists instead of ignoring the new value. You can replace existing calls to `Set` with `TryAdd` if you depended on the previous functionality.