### PR TITLE
fix: suggest Meta attribute in blackboard error

### DIFF
--- a/Chickensoft.Collections/src/collections/blackboard/Blackboard.cs
+++ b/Chickensoft.Collections/src/collections/blackboard/Blackboard.cs
@@ -83,7 +83,7 @@ public class Blackboard : IBlackboard {
     _blackboard.TryGetValue(type, out var data)
       ? data
       : throw new KeyNotFoundException(
-        $"Data of type {type} not found in the blackboard."
+        $"Data of type {type} not found in the blackboard. (You may be missing the [Meta] attribute.)"
       );
 
   /// <summary>


### PR DESCRIPTION
When the blackboard does not contain the requested type, updated the exception's error message to suggest to the user that they may need to add the Meta attribute to the blackboard's owning type.