### PR TITLE
Fix example for `Pool` collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ Any object you wish to store in a pool must conform to `IPooled` and implement t
     public void Reset() { }
   }
 
-  public class Cube : Entity { }
-  public class Sphere : Entity { }
+  public class Cube : Shape { }
+  public class Sphere : Shape { }
 ```
 
 A pool can be easily created. Each derived type that you wish to pool can be "registered" with the pool. The pool will create instances of each type registered with it according to the provided capacity.


### PR DESCRIPTION
It looks like the code snippet references an unknown class, `Entity`. I believe it was meant to be `Shape`, since the following code expects both `Cube` and `Sphere` to implement a `Reset` method.